### PR TITLE
Update repository regexp to allow slashes in repository name

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -131,7 +131,7 @@ func validRepositoryRole(role quay.RepositoryRole) bool {
 var (
 	userRegexp  = regexp.MustCompile(`^[a-z0-9][.a-z0-9_-]*$`)
 	teamRegexp  = regexp.MustCompile(`^[a-z][a-z0-9]+$`)
-	repoRegexp  = regexp.MustCompile(`^[a-z0-9][.a-z0-9_-]*$`)
+	repoRegexp  = regexp.MustCompile(`^[a-z0-9][.a-z0-9_-]*(/[a-z0-9][.a-z0-9_-]*)*$`)
 	robotRegexp = regexp.MustCompile(`^[a-z][a-z0-9_]{1,254}$`)
 	orgRegexp   = regexp.MustCompile(`^[a-z0-9][.a-z0-9_-]{1,254}$`)
 )


### PR DESCRIPTION
This PR updates repository regexp based on the current rules (see the screenshot below):

![Screenshot 2023-01-10 at 16 37 12](https://user-images.githubusercontent.com/15926980/211757233-e4b07d7c-3511-4ae3-aa53-67d42f25d926.png)

Most importantly, it allows slashes in repo names. That is needed for hosting Helm charts in an organised way, e.g.:

```
helm push <helm-chart>.tgz oci://quay.io/<org-name>/helm-charts
```

would create a repo with the name derived from the helm chart name:

```
<org-name>/helm-charts/<helm-chart-name>
```

(example: https://quay.io/repository/rastislavtest/helm-charts/cilium - tested with this change)

This is necessary for https://github.com/kubermatic/access/pull/860


**Release Note**:
```release-note
Update repository regexp to allow slashes in repository name.
```
